### PR TITLE
Properly close aiohttp session

### DIFF
--- a/RedGalaxy/session.py
+++ b/RedGalaxy/session.py
@@ -117,7 +117,12 @@ class SessionManager:
                                           "consumer key+secret.")
 
     def __del__(self):
-        asyncio.get_event_loop().run_until_complete(self.session.close())
+        try:
+            loop = asyncio.get_event_loop()
+            loop.create_task(self.session.close())
+        except Exception:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(self.session.close())
 
 
 global_instance = SessionManager(SessionMode.BEARER, _DEFAULT_BEARER)


### PR DESCRIPTION
Without a context manager the session gets destroyed after the asyncio eventloop is finished thus causing errors at exit.
Replacing aiohttp with httpx is also a possibility as the latter doesn't cry if not explicitly closed
> Unclosed client session
> client_session: <aiohttp.client.ClientSession object at 0x7f3d34105b20>
> Unclosed connector
> connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7f3d34124d00>, 608497.920845252)]', '[(<aiohttp.client_proto.ResponseHandler object at 0x7f3d340fb2e0>, 608499.810311891)]']
> connector: <aiohttp.connector.TCPConnector object at 0x7f3d34105c10>